### PR TITLE
Two fixes related to UTF-8-support

### DIFF
--- a/inc.php
+++ b/inc.php
@@ -31,6 +31,8 @@ if (!extension_loaded('mbstring')) die('The PHP-extension for multibyte support 
 include("db_settings.php");
 include("functions.php");
 
+mb_internal_encoding('UTF-8');
+
 # for details see: http://de.php.net/manual/en/security.magicquotes.disabling.php
 if (get_magic_quotes_gpc()) {
 	$_POST = array_map('stripslashes_deep', $_POST);

--- a/inc.php
+++ b/inc.php
@@ -27,6 +27,7 @@ header('Content-Type: text/html; charset=UTF-8');
 #ini_set("session.use_trans_sid","0");
 session_start();
 
+if (!extension_loaded('mbstring')) die('The PHP-extension for multibyte support is mandatory. The script will not work without the extension.');
 include("db_settings.php");
 include("functions.php");
 


### PR DESCRIPTION
- The multibyte-extension of PHP is mandatory for the script beginning with version 1.8. Add a check for the extension and deny the work without.
- Set the script internal charset to UTF-8 so the multibyte functions will use it.