### PR TITLE
Change: do not split cited lines every time a new reply gets written

### DIFF
--- a/posting.php
+++ b/posting.php
@@ -174,7 +174,6 @@ if ($settings['entries_by_users_only'] == 1 && isset($_SESSION[$settings['sessio
           $p_category = $field["category"];
           $text = $field["text"];
           $aname = $field["name"];
-          $text = wordwrap($text);
           // Zitatzeichen an den Anfang jeder Zeile stellen:
           $text = preg_replace("/^/m", $settings['quote_symbol']." ", $text);
          }


### PR DESCRIPTION
With every new reply with cited text in, the length of every cited text lines gets newly determined and when it exceeds 78 chars the line gets splitted to a length of under 78 chars. That caused single words to wrap into a new line because of the quote chars that was added before. So the cites will get orphaned words in extra lines.

in example:

```
// the original text:
An example with a few words that will break when cited.
// first level as cite:
> An example with a few words that will break when
> cited.
// second level as cite in a cite
> > An example with a few words that will break
> > when
> > cited.
// and so forth
```

To prevent this, I remove the function wordwrap in the code to read the posting, one wants to reply to. A paragraph of text will now get handled as a paragraph and not as a bunch of text that should get formatted as a number of text lines.

