### PR TITLE
Replace md5 with password_hash to store passwords in a more secure way

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -202,7 +202,24 @@ if(isset($_POST['sql_submit']))
   if ($_POST['sql_pw']=='') $errors[] = $lang['error_form_uncompl'];
   else
    {
-    if ($field['user_pw'] != md5(trim($_POST['sql_pw']))) $errors[] = $lang['pw_wrong'];
+    if (mb_strlen($field["user_pw"]) == 32) {
+      if ($field["user_pw"] == md5($_POST['sql_pw'])) {
+        $positive = true;
+      } else {
+        $positive = false;
+      }
+      if ($positive === true) {
+        $new_hash = password_hash($_POST['sql_pw'], PASSWORD_DEFAULT);
+        $qNewPassword = "UPDATE ". $db_settings['userdata_table'] ." SET last_login=last_login, registered=registered, user_pw = '". mysqli_real_escape_string($connid, $new_hash) ."' WHERE user_id = ". intval($feld["user_id"]);
+        $rNewPassword = mysqli_query($connid, $qNewPassword);
+        if ($rNewPassword === true) {
+          $field["user_pw"] = $new_hash;
+        }
+      }
+    } else {
+      $positive = password_verify($_POST['sql_pw'], $field["user_pw"]);
+    }
+    if ($positive === false) $errors[] = $lang['pw_wrong'];
    }
 
   if(empty($errors))
@@ -601,7 +618,24 @@ if (isset($_POST['delete_all_postings_confirmed']))
   if ($_POST['delete_all_postings_confirm_pw']=="") $errors[] = $lang['error_form_uncompl'];
   else
    {
-    if ($field['user_pw'] != md5(trim($_POST['delete_all_postings_confirm_pw']))) $errors[] = $lang['pw_wrong'];
+    if (mb_strlen($field["user_pw"]) == 32) {
+      if ($field["user_pw"] == md5($_POST['delete_all_postings_confirm_pw'])) {
+        $positive = true;
+      } else {
+        $positive = false;
+      }
+      if ($positive === true) {
+        $new_hash = password_hash($_POST['delete_all_postings_confirm_pw'], PASSWORD_DEFAULT);
+        $qNewPassword = "UPDATE ". $db_settings['userdata_table'] ." SET last_login=last_login, registered=registered, user_pw = '". mysqli_real_escape_string($connid, $new_hash) ."' WHERE user_id = ". intval($feld["user_id"]);
+        $rNewPassword = mysqli_query($connid, $qNewPassword);
+        if ($rNewPassword === true) {
+          $field["user_pw"] = $new_hash;
+        }
+      }
+    } else {
+      $positive = password_verify($_POST['delete_all_postings_confirm_pw'], $field["user_pw"]);
+    }
+    if ($positive === false) $errors[] = $lang['pw_wrong'];
    }
   if (empty($errors))
    {
@@ -621,7 +655,16 @@ if (isset($_POST['delete_db_confirmed']))
   if ($_POST['delete_db_confirm_pw']=="" || empty($_POST['delete_modus'])) $errors[] = $lang['error_form_uncompl'];
   else
    {
-    if ($field['user_pw'] != md5(trim($_POST['delete_db_confirm_pw']))) $errors[] = $lang['pw_wrong'];
+    if (mb_strlen($field["user_pw"]) == 32) {
+      if ($field["user_pw"] == md5($_POST['delete_db_confirm_pw'])) {
+        $positive = true;
+      } else {
+        $positive = false;
+      }
+    } else {
+      $positive = password_verify($_POST['delete_db_confirm_pw'], $field["user_pw"]);
+    }
+    if ($positive === false) $errors[] = $lang['pw_wrong'];
    }
   if (empty($errors))
    {
@@ -810,7 +853,7 @@ if (isset($_POST['ar_username']))
       $ar_pw="";
       for($i=0;$i<8;$i++) { $ar_pw .= mb_substr($letters, mt_rand(0, mb_strlen($letters) - 1), 1); }
      }
-    $encoded_ar_pw = md5($ar_pw);
+    $encoded_ar_pw = password_hash($ar_pw, PASSWORD_DEFAULT);
     $new_user_result = mysqli_query($connid, "INSERT INTO ". $db_settings['userdata_table'] ." (user_type, user_name, user_pw, user_email, hide_email, profile, last_login, last_logout, user_ip, registered, user_view, personal_messages) VALUES ('user','". mysqli_real_escape_string($connid, $ar_username) ."','". mysqli_real_escape_string($connid, $encoded_ar_pw) ."','". mysqli_real_escape_string($connid, $ar_email) ."','1','',NOW(),NOW(),'". mysqli_real_escape_string($connid, $_SERVER["REMOTE_ADDR"]) ."',NOW(),'". mysqli_real_escape_string($connid, $settings['standard']) ."',1)");
     if(!$new_user_result) die($lang['db_error']);
 

--- a/install.php
+++ b/install.php
@@ -505,7 +505,7 @@ if (isset($_POST['form_submitted']))
      // insert admin in userdata table:
      if (empty($errors))
       {
-       @mysqli_query($connid, "INSERT INTO ". $db_settings['userdata_table'] ." (user_type, user_name, user_real_name, user_pw, user_email, hide_email, profile, registered, user_view, personal_messages) VALUES ('admin','". mysqli_real_escape_string($connid, $_POST['admin_name']) ."','','". mysqli_real_escape_string($connid, md5(trim($_POST['admin_pw'])))."','". mysqli_real_escape_string($connid, $_POST['admin_email']) ."','1','',NOW(),'". mysqli_real_escape_string($connid, $settings['standard']) ."','1')") or $errors[] = $lang_add['insert_admin_error']." (MySQL: ".mysqli_error($connid).")";
+       @mysqli_query($connid, "INSERT INTO ". $db_settings['userdata_table'] ." (user_type, user_name, user_real_name, user_pw, user_email, hide_email, profile, registered, user_view, personal_messages) VALUES ('admin','". mysqli_real_escape_string($connid, $_POST['admin_name']) ."','','". mysqli_real_escape_string($connid, password_hash(trim($_POST['admin_pw']), PASSWORD_DEFAULT))."','". mysqli_real_escape_string($connid, $_POST['admin_email']) ."','1','',NOW(),'". mysqli_real_escape_string($connid, $settings['standard']) ."','1')") or $errors[] = $lang_add['insert_admin_error']." (MySQL: ".mysqli_error($connid).")";
       }
 
      // insert settings in settings table:

--- a/login.php
+++ b/login.php
@@ -74,8 +74,24 @@ switch ($action)
      if (mysqli_num_rows($result) == 1)
       {
        $feld = mysqli_fetch_assoc($result);
-
-     if ($feld["user_pw"] == md5($userpw))
+      if (mb_strlen($feld["user_pw"]) == 32) {
+        if ($feld["user_pw"] == md5($userpw)) {
+          $positive = true;
+        } else {
+          $positive = false;
+        }
+        if ($positive === true) {
+          $new_hash = password_hash($userpw, PASSWORD_DEFAULT);
+          $qNewPassword = "UPDATE ". $db_settings['userdata_table'] ." SET last_login=last_login, registered=registered, user_pw = '". mysqli_real_escape_string($connid, $new_hash) ."' WHERE user_id = ". intval($feld["user_id"]);
+          $rNewPassword = mysqli_query($connid, $qNewPassword);
+          if ($rNewPassword === true) {
+            $feld["user_pw"] = $new_hash;
+          }
+        }
+      } else {
+        $positive = password_verify($userpw, $feld["user_pw"]);
+      }
+     if ($positive === true)
       {
        if (trim($feld["activate_code"]) != '')
         {

--- a/login.php
+++ b/login.php
@@ -231,7 +231,7 @@ switch ($action)
       mt_srand ((double)microtime()*1000000);
       $new_user_pw="";
       for($i=0;$i<8;$i++) { $new_user_pw .= mb_substr($letters, mt_rand(0, mb_strlen($letters) - 1), 1); }
-      $encoded_new_user_pw = md5($new_user_pw);
+      $encoded_new_user_pw = password_hash($new_user_pw, PASSWORD_DEFAULT);
       $update_result = mysqli_query($connid, "UPDATE ". $db_settings['userdata_table'] ." SET last_login=last_login, registered=registered, user_pw='". mysqli_real_escape_string($connid, $encoded_new_user_pw) ."', pwf_code='' WHERE user_id=". intval($field["user_id"]) ." LIMIT 1");
 
       // send new password:

--- a/register.php
+++ b/register.php
@@ -177,7 +177,7 @@ if(isset($_POST['register_submit']))
    // save user if no errors:
    if (empty($errors))
     {
-     $encoded_new_user_pw = md5($reg_pw);
+     $encoded_new_user_pw = password_hash($reg_pw, PASSWORD_DEFAULT);
      $activate_code = md5(uniqid(rand()));
      @mysqli_query($connid, "INSERT INTO ". $db_settings['userdata_table'] ." (user_type, user_name, user_pw, user_email, hide_email, profile, last_login, last_logout, user_ip, registered, user_view, personal_messages, activate_code) VALUES ('user','". mysqli_real_escape_string($connid, $new_user_name) ."','". mysqli_real_escape_string($connid, $encoded_new_user_pw) ."','". mysqli_real_escape_string($connid, $new_user_email) ."','1','',NOW(),NOW(),'". mysqli_real_escape_string($connid, $_SERVER["REMOTE_ADDR"]) ."',NOW(),'". mysqli_real_escape_string($connid, $settings['standard']) ."','1', '". mysqli_real_escape_string($connid, $activate_code) ."')") or die($lang['db_error']);
 


### PR DESCRIPTION
The passwords for new registered users are stored from now on with the function `password_hash`. Passwords of yet registered users will be compared with the old md5-implementation in case of a hash with a stringlength of 32 chars. In this case I assume the hash was made with md5. When the comparision succeedes, a new hash will get generated with `password_hash` and this new hash replaces the old md5-based hash in the users dataset.

The same procedure get executed in case of the forgot-password-function when one confirm the generate-new-password-link in the e-mail.

This fixes #38.