### PR TITLE
Change: set charset of the RSS-feed explicitely to UTF-8

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -35,8 +35,8 @@ include("inc.php");
    if(!$result) die($lang['db_error']);
   }
 $result_count = mysqli_num_rows($result);
-header("Content-Type: text/xml; charset: ".$lang['charset']);
-echo '<?xml version="1.0" encoding="'.$lang['charset'].'"?>';
+header("Content-Type: text/xml; charset:  utf-8");
+echo '<?xml version="1.0" encoding="UTF-8"?>';
 ?>
 <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 <channel>


### PR DESCRIPTION
The content gets always delivered in UTF-8, so enforce the correct charset in the XML-document.