### PR TITLE
Fix: render the result list only in the case of an existing resultset

### DIFF
--- a/search.php
+++ b/search.php
@@ -133,17 +133,15 @@ $$key = $value;
  if (is_array($categories))
   {
    $result = mysqli_query($connid, "SELECT id, pid, tid, UNIX_TIMESTAMP(time + INTERVAL ". $time_difference ." HOUR) AS Uhrzeit, subject, name, email, hp, place, text, category FROM ". $db_settings['forum_table'] ." WHERE ". $search_string ." AND category IN (". $category_ids_query .") ORDER BY tid DESC, time ASC LIMIT ". intval($ul) .", ". intval($settings['search_results_per_page']));
-   $count_result = mysqli_query($connid, "SELECT COUNT(*) FROM ". $db_settings['forum_table'] ." WHERE ". $search_string ." AND category IN (". $category_ids_query .")");
-   list($count) = mysqli_fetch_row($count_result);
   }
  else
   {
    $result = mysqli_query($connid, "SELECT id, pid, tid, UNIX_TIMESTAMP(time + INTERVAL ". $time_difference ." HOUR) AS Uhrzeit, subject, name, email, hp, place, text, category FROM ". $db_settings['forum_table'] ." WHERE ". $search_string ." ORDER BY tid DESC, time ASC LIMIT ". intval($ul) .", ". intval($settings['search_results_per_page']));
-   $count_result = mysqli_query($connid, "SELECT COUNT(*) FROM ". $db_settings['forum_table'] ." WHERE ". $search_string);
-   list($count) = mysqli_fetch_row($count_result);
   }
 
  if(!$result) die($lang['db_error']);
+
+$count = mysqli_num_rows($result);
 
  // HTML:
 $wo = $lang['search_title'];

--- a/search.php
+++ b/search.php
@@ -274,7 +274,7 @@ if (!empty($notification)) {
 	echo $noteAll;
 }
 
-if ((isset($search) && $search != "") || (isset($show_postings) && $show_postings !="")) {
+if (((isset($search) && $search != "") || (isset($show_postings) && $show_postings !="")) and $count > 0) {
 	$xmlResultList = simplexml_load_file($settings['themepath'] .'/templates/general-ul-list.xml', null, LIBXML_NOCDATA);
 	$listAll = $xmlResultList->wholelist;
 	$listBody = $xmlResultList->item;


### PR DESCRIPTION
Before this PR the script created always the structure for the searchresult-list, even there was no results in the resultset. This happens since the introduction of the first templates in the rework of the theme (see also #49).